### PR TITLE
Add NeuralNetwork unit tests

### DIFF
--- a/Flappy Bird/tests/test_nn.py
+++ b/Flappy Bird/tests/test_nn.py
@@ -1,0 +1,24 @@
+import os
+import sys
+import numpy as np
+
+# Add the src directory to the import path
+sys.path.append(os.path.join(os.path.dirname(__file__), '..', 'src'))
+
+from nn import NeuralNetwork
+
+
+def test_get_set_weights_roundtrip():
+    nn = NeuralNetwork()
+    weights = nn.get_weights().copy()
+    # Modify weights to ensure set_weights works (optional)
+    nn.set_weights(weights)
+    np.testing.assert_array_equal(weights, nn.get_weights())
+
+
+def test_forward_output_shape():
+    nn = NeuralNetwork()
+    x = np.zeros(3)
+    out = nn.forward(x)
+    assert isinstance(out, np.ndarray)
+    assert out.shape == (1, 1)

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,3 @@
 pygame
 numpy
+pytest


### PR DESCRIPTION
## Summary
- add tests for `NeuralNetwork` round-trip weights and forward output shape
- include `pytest` in requirements

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'numpy')*

------
https://chatgpt.com/codex/tasks/task_e_6883dc1dd7c8832386032db6371ab935