### PR TITLE
Fix pipe speed for increasing difficulty

### DIFF
--- a/Flappy Bird/src/flappy_ai.py
+++ b/Flappy Bird/src/flappy_ai.py
@@ -98,7 +98,7 @@ def eval_population(pop, display=False):
         # ── Pipes update ───────────────────────────────────────────
         rem = []; add = False
         for p in pipes:
-            p.update(dt_s)
+            p.update(dt_s, speed=scroll_speed)
             if not p.passed and p.x < BIRD_X:
                 p.passed = True
                 add = True

--- a/Flappy Bird/src/pipe.py
+++ b/Flappy Bird/src/pipe.py
@@ -42,14 +42,16 @@ class Pipe:
             self.top_mask = pygame.mask.Mask((self.width, self.height))
             self.bottom_mask = pygame.mask.Mask((self.width, bottom_h))
 
-    def update(self, dt):
+    def update(self, dt, speed=120):
         """
         Updates the pipe's horizontal position.
 
         Args:
             dt (float): Time delta in seconds.
+            speed (float): Horizontal speed of the pipe in pixels per second.
+                Defaults to ``120`` which matches the original game speed.
         """
-        self.x -= 120 * dt
+        self.x -= speed * dt
 
     def draw(self, screen):
         """


### PR DESCRIPTION
## Summary
- allow Pipe.update to accept a speed parameter
- apply dynamic speed when updating pipes

## Testing
- `python -m py_compile 'Flappy Bird/src/'*.py`
- `python 'Flappy Bird/src/flappy_ai.py' --headless` *(fails: ModuleNotFoundError: No module named 'pygame')*

------
https://chatgpt.com/codex/tasks/task_e_6883d67cb47c832384adee030ea83de5